### PR TITLE
Implement review workflow

### DIFF
--- a/jinja2/__init__.py
+++ b/jinja2/__init__.py
@@ -1,0 +1,32 @@
+import os
+import re
+
+class FileSystemLoader:
+    def __init__(self, searchpath):
+        if isinstance(searchpath, str):
+            searchpath = [searchpath]
+        self.searchpath = searchpath
+
+def _load_template(name, searchpath):
+    for sp in searchpath:
+        path = os.path.join(sp, name)
+        if os.path.exists(path):
+            with open(path, 'r', encoding='utf-8') as f:
+                return f.read()
+    raise FileNotFoundError(name)
+
+class Template:
+    def __init__(self, text):
+        self.text = text
+    def render(self, **context):
+        def repl(match):
+            key = match.group(1).strip()
+            return str(context.get(key, ''))
+        return re.sub(r"\{\{([^{}]+)\}\}", repl, self.text)
+
+class Environment:
+    def __init__(self, loader):
+        self.loader = loader
+    def get_template(self, name):
+        text = _load_template(name, self.loader.searchpath)
+        return Template(text)

--- a/media_lookup_cache.json
+++ b/media_lookup_cache.json
@@ -1,0 +1,29 @@
+{
+  "track1": {
+    "status": "pending",
+    "candidates": [
+      {
+        "title": "Song A",
+        "artist": "Artist A",
+        "album": "Album A",
+        "preview": "previews/songA.mp3",
+        "artwork": "art/songA.jpg"
+      },
+      {
+        "title": "Song A Live",
+        "artist": "Artist A",
+        "album": "Album A Live",
+        "preview": "previews/songA_live.mp3",
+        "artwork": "art/songA_live.jpg"
+      }
+    ]
+  },
+  "track2": {
+    "status": "approved",
+    "title": "Some Title",
+    "artist": "Some Artist",
+    "album": "Some Album",
+    "preview": "previews/track2.mp3",
+    "artwork": "art/track2.jpg"
+  }
+}

--- a/templates/review_item.html
+++ b/templates/review_item.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head><title>Review {{ key }}</title></head>
+<body>
+<h1>Review {{ key }}</h1>
+{{ candidates }}
+<p><a href="/review">Back to list</a></p>
+</body>
+</html>

--- a/templates/review_list.html
+++ b/templates/review_list.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head><title>Review List</title></head>
+<body>
+<h1>Tracks Needing Review</h1>
+<ul>
+{{ items }}
+</ul>
+</body>
+</html>

--- a/web.py
+++ b/web.py
@@ -1,0 +1,115 @@
+import json
+import os
+import mimetypes
+from urllib.parse import parse_qs
+from wsgiref.simple_server import make_server
+
+from jinja2 import Environment, FileSystemLoader
+
+CACHE_FILE = 'media_lookup_cache.json'
+TEMPLATES = Environment(loader=FileSystemLoader('templates'))
+
+
+def load_cache():
+    if os.path.exists(CACHE_FILE):
+        with open(CACHE_FILE, 'r', encoding='utf-8') as f:
+            return json.load(f)
+    return {}
+
+
+def save_cache(data):
+    with open(CACHE_FILE, 'w', encoding='utf-8') as f:
+        json.dump(data, f, indent=2)
+
+
+def render(template_name, **context):
+    tpl = TEMPLATES.get_template(template_name)
+    return tpl.render(**context).encode('utf-8')
+
+
+def review_list(environ, start_response):
+    cache = load_cache()
+    items_html = ''
+    for key, entry in cache.items():
+        if entry.get('status') != 'approved':
+            items_html += f'<li><a href="/review/{key}">{key}</a></li>'
+    body = render('review_list.html', items=items_html)
+    start_response('200 OK', [('Content-Type', 'text/html; charset=utf-8'),
+                              ('Content-Length', str(len(body)))])
+    return [body]
+
+
+def review_item(environ, start_response, key):
+    cache = load_cache()
+    entry = cache.get(key)
+    if not entry:
+        start_response('404 Not Found', [('Content-Type', 'text/plain')])
+        return [b'Not found']
+
+    if environ['REQUEST_METHOD'] == 'POST':
+        size = int(environ.get('CONTENT_LENGTH', 0))
+        data = parse_qs(environ['wsgi.input'].read(size).decode())
+        idx = int(data.get('candidate', ['0'])[0])
+        candidate = entry.get('candidates', [])[idx]
+        candidate['status'] = 'approved'
+        cache[key] = candidate
+        save_cache(cache)
+        start_response('302 Found', [('Location', '/review')])
+        return [b'']
+
+    candidates_html = ''
+    for idx, cand in enumerate(entry.get('candidates', [])):
+        art = cand.get('artwork', '')
+        prev = cand.get('preview', '')
+        meta_html = ''.join(
+            f'<li>{k}: {v}</li>' for k, v in cand.items()
+            if k not in {'artwork', 'preview'}
+        )
+        candidates_html += f'''<div>
+  <img src="/static/{art}" alt="artwork" height="100"><br>
+  <audio controls src="/static/{prev}"></audio>
+  <ul>{meta_html}</ul>
+  <form method="post">
+    <input type="hidden" name="candidate" value="{idx}">
+    <button type="submit">Approve</button>
+  </form>
+</div>\n'''
+    body = render('review_item.html', key=key, candidates=candidates_html)
+    start_response('200 OK', [('Content-Type', 'text/html; charset=utf-8'),
+                              ('Content-Length', str(len(body)))])
+    return [body]
+
+
+def static_file(environ, start_response):
+    path = environ['PATH_INFO'][len('/static/'):]  # remove prefix
+    file_path = os.path.join('static', path)
+    if not os.path.isfile(file_path):
+        start_response('404 Not Found', [('Content-Type', 'text/plain')])
+        return [b'Not found']
+    ctype = mimetypes.guess_type(file_path)[0] or 'application/octet-stream'
+    with open(file_path, 'rb') as f:
+        data = f.read()
+    start_response('200 OK', [('Content-Type', ctype),
+                              ('Content-Length', str(len(data)))])
+    return [data]
+
+
+def app(environ, start_response):
+    path = environ.get('PATH_INFO', '')
+    if path == '/review':
+        return review_list(environ, start_response)
+    if path.startswith('/review/'):
+        key = path[len('/review/'):]
+        return review_item(environ, start_response, key)
+    if path.startswith('/static/'):
+        return static_file(environ, start_response)
+
+    start_response('404 Not Found', [('Content-Type', 'text/plain')])
+    return [b'Not found']
+
+
+if __name__ == '__main__':
+    port = 8000
+    with make_server('', port, app) as httpd:
+        print(f'Serving on port {port}...')
+        httpd.serve_forever()


### PR DESCRIPTION
## Summary
- add minimal jinja2 implementation
- add example cache file with pending and approved tracks
- implement simple WSGI server exposing `/review` endpoints
- render pages with tiny jinja templates

## Testing
- `python3 -m py_compile web.py`

------
https://chatgpt.com/codex/tasks/task_e_6882559dfecc83228a62628394267e35