### PR TITLE
Add builtin downloader support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
-# JSON_CHANGER-media-gen
+# JSON_CHANGER Media Generator
+
+This project provides a simple script (`main.py`) for downloading album artwork
+and preview MP3 files from iTunes search results. The media is stored in
+`media/music/{Artist}/{Album}/`. The script uses only Python's standard
+library, so no additional packages are required.
+
+## Usage
+
+1. Obtain an iTunes search results JSON file. The file should contain a `results` array where each item may include `artistName`, `collectionName`, `previewUrl` and `artworkUrl100` fields.
+2. Run the script:
+
+```bash
+python3 main.py results.json
+```
+
+For each result the script will ask for confirmation before downloading. Album artwork is downloaded in 600x600 resolution. Existing artwork and preview files are reused.

--- a/main.py
+++ b/main.py
@@ -1,0 +1,75 @@
+import argparse
+import json
+import os
+import sys
+from urllib.parse import urlparse
+
+from urllib.request import urlopen
+
+
+def sanitize(name: str) -> str:
+    """Sanitize a string for safe filesystem usage."""
+    return ''.join(c for c in name if c.isalnum() or c in ' -_').strip()
+
+
+def ensure_dir(path: str) -> None:
+    os.makedirs(path, exist_ok=True)
+
+
+def download_file(url: str, dest_path: str) -> None:
+    with urlopen(url) as response, open(dest_path, 'wb') as f:
+        f.write(response.read())
+
+
+def artwork_600(url100: str) -> str:
+    return url100.replace('100x100', '600x600')
+
+
+def handle_result(result: dict, base_dir: str) -> None:
+    artist = sanitize(result.get('artistName', 'Unknown Artist'))
+    album = sanitize(result.get('collectionName', 'Unknown Album'))
+    artwork = result.get('artworkUrl100')
+    preview = result.get('previewUrl')
+
+    target_dir = os.path.join(base_dir, artist, album)
+    ensure_dir(target_dir)
+
+    approve = input(f"Download media for {artist} - {album}? [y/N]: ")
+    if approve.lower() != 'y':
+        return
+
+    if artwork:
+        artwork_path = os.path.join(target_dir, 'artwork.jpg')
+        if not os.path.exists(artwork_path):
+            art_url = artwork_600(artwork)
+            try:
+                download_file(art_url, artwork_path)
+            except Exception as e:
+                print(f"Failed to download artwork: {e}", file=sys.stderr)
+
+    if preview:
+        filename = os.path.basename(urlparse(preview).path) or 'preview.mp3'
+        preview_path = os.path.join(target_dir, filename)
+        if not os.path.exists(preview_path):
+            try:
+                download_file(preview, preview_path)
+            except Exception as e:
+                print(f"Failed to download preview: {e}", file=sys.stderr)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Download iTunes media previews")
+    parser.add_argument('json', help='Path to iTunes search results JSON')
+    parser.add_argument('--dest', default='media/music', help='Destination directory')
+    args = parser.parse_args()
+
+    with open(args.json, 'r', encoding='utf-8') as f:
+        data = json.load(f)
+
+    results = data.get('results', [])
+    for result in results:
+        handle_result(result, args.dest)
+
+
+if __name__ == '__main__':
+    main()

--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ import os
 import sys
 from urllib.parse import urlparse
 
+import re
 from urllib.request import urlopen
 
 
@@ -22,7 +23,8 @@ def download_file(url: str, dest_path: str) -> None:
 
 
 def artwork_600(url100: str) -> str:
-    return url100.replace('100x100', '600x600')
+    """Convert a 100x100 artwork URL to 600x600."""
+    return re.sub(r"100x100bb", "600x600bb", url100)
 
 
 def handle_result(result: dict, base_dir: str) -> None:


### PR DESCRIPTION
## Summary
- switch main.py to use `urllib` instead of the `requests` package
- clarify in README that the script uses only the Python standard library

## Testing
- `python3 -m py_compile main.py`
- Ran script manually with sample JSON to ensure it prompts correctly

------
https://chatgpt.com/codex/tasks/task_e_6882559fbb308322a9ee3d7384ef6bf3