### PR TITLE
Ensure status saved with media cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ python main.py
 Open `http://localhost:8000` and mark each entry as approved. Approved files remain available in the `media` folder.
 
 ### 3. Download
-After approval you can process the assets further or transfer them to their final destination. The approval status is stored alongside the file path in `media_lookup_cache.json`.
+After approval you can process the assets further or transfer them to their final destination. The status field (`auto` or `approved`) is stored alongside the file path in `media_lookup_cache.json`.
 
 ## Additional utilities
 

--- a/ingest.py
+++ b/ingest.py
@@ -25,10 +25,10 @@ def download_media(url: str, filename: str | None = None) -> Path:
 
 def update_cache(url: str, path: Path) -> None:
     """Record downloaded media in the cache."""
-    data = {}
+    data: dict = {}
     if CACHE_FILE.exists():
         data = json.loads(CACHE_FILE.read_text())
-    data[url] = {"path": str(path), "approved": False}
+    data[url] = {"path": str(path), "status": "auto"}
     CACHE_FILE.write_text(json.dumps(data, indent=2))
 
 

--- a/media_lookup_cache.json
+++ b/media_lookup_cache.json
@@ -1,7 +1,6 @@
-
 {
   "track1": {
-    "status": "pending",
+    "status": "auto",
     "candidates": [
       {
         "title": "Song A",
@@ -28,5 +27,3 @@
     "artwork": "art/track2.jpg"
   }
 }
-=======
-{}

--- a/metadata_lookup.py
+++ b/metadata_lookup.py
@@ -104,7 +104,7 @@ def process_library(library_path: str) -> None:
                 continue
 
         if result:
-            cache[key] = result
+            cache[key] = {"status": "auto", **result}
             updated = True
 
     if updated:

--- a/templates/index.html
+++ b/templates/index.html
@@ -9,7 +9,7 @@
 {% for url, info in media.items() %}
     <li>
         <a href="{{ info['path'] }}">{{ url }}</a>
-        {% if info['approved'] %}
+        {% if info['status'] == 'approved' %}
             <span>Approved</span>
         {% else %}
             <form action="/approve" method="post" style="display:inline;">


### PR DESCRIPTION
## Summary
- record downloaded media with `status: auto`
- mark iTunes lookup results with the same status
- update README on cache status information
- fix stale template logic for status
- clean up `media_lookup_cache.json`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688271f7e5e083228e228da187b2e59e