### PR TITLE
Add email placeholders to env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,6 @@
 SMTP_HOST=your.smtp.host
 SMTP_PORT=587
 SMTP_USER=your_username
-SMTP_PASSWORD=your_password
+SMTP_PASS=your_password
+EMAIL_FROM=sender@example.com
+EMAIL_TO=recipient@example.com


### PR DESCRIPTION
## Summary
- update `.env.example` with `EMAIL_FROM` and `EMAIL_TO`
- rename `SMTP_PASSWORD` to `SMTP_PASS` for consistency

## Testing
- `python -m py_compile notify_missing_media.py main.py ingest.py itunes_json_ingest.py metadata_lookup.py web.py`

------
https://chatgpt.com/codex/tasks/task_e_68827419c5808322b7483a0589c24b35