### PR TITLE
Add station library upload via web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ python main.py
 ```
 
 Open `http://localhost:8000` and mark each entry as approved. Approved files remain available in the `media` folder.
+You can upload a replacement station library at `/library` if the metadata source changes.
 
 ### 3. Download
 After approval you can process the assets further or transfer them to their final destination. The status field (`auto` or `approved`) is stored alongside the file path in `media_lookup_cache.json`.

--- a/templates/review_list.html
+++ b/templates/review_list.html
@@ -3,6 +3,7 @@
 <head><title>Review List</title></head>
 <body>
 <h1>Tracks Needing Review</h1>
+<p><a href="/library">Upload Station Library</a></p>
 <ul>
 {{ items }}
 </ul>

--- a/templates/upload_library.html
+++ b/templates/upload_library.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head><title>Upload Library</title></head>
+<body>
+<h1>Upload Station Library</h1>
+<form action="/library" method="post" enctype="multipart/form-data">
+    <input type="file" name="file">
+    <button type="submit">Upload</button>
+</form>
+<p><a href="/review">Back to list</a></p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- enable uploading station library through the FastAPI app
- link to upload page from the review list
- document the new upload feature

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6882816faaac8322a75edee0cadd3918